### PR TITLE
Removed PHP short tag

### DIFF
--- a/src/protocolbuf/message/pb_message.php
+++ b/src/protocolbuf/message/pb_message.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * Including of all files needed to parse messages
  * @author Nikolai Kordulla


### PR DESCRIPTION
Hey,

Small tweak - removed PHP shorttag `<?` (changed it to proper `<?php`) as using short tags is not recommended and will break on servers where `php.ini` setting `short_open_tag` is turned off.

This is in `PBMessage` class/lib, but I don't see much activity in that project, so need to remember about it if it ever gets updated.
