### PR TITLE
Add "documentFormat" option

### DIFF
--- a/rdb/Connection.php
+++ b/rdb/Connection.php
@@ -227,7 +227,7 @@ class Connection extends DatumConverter
 
         // Grab PHP-RQL specific options
         $toNativeOptions = array();
-        foreach (array('binaryFormat', 'timeFormat') as $opt) {
+        foreach (array('binaryFormat', 'timeFormat', 'documentFormat') as $opt) {
             if (isset($options) && isset($options[$opt])) {
                 $toNativeOptions[$opt] = $options[$opt];
                 unset($options[$opt]);

--- a/rdb/Connection.php
+++ b/rdb/Connection.php
@@ -271,7 +271,6 @@ class Connection extends DatumConverter
         } else {
             return $this->createCursorFromResponse($response, $token, $response['n'], $toNativeOptions);
         }
-
     }
 
     public function continueQuery($token)

--- a/rdb/Datum/ObjectDatum.php
+++ b/rdb/Datum/ObjectDatum.php
@@ -48,7 +48,11 @@ class ObjectDatum extends Datum
 
     public function toNative($opts)
     {
-        $native = new \ArrayObject();
+        if (isset($opts['documentFormat']) && $opts['documentFormat'] == 'array') {
+            $native = array();
+        } else {
+            $native = new \ArrayObject();
+        }
         foreach ($this->getValue() as $key => $val) {
             $native[$key] = $val->toNative($opts);
         }

--- a/rdb/DatumConverter.php
+++ b/rdb/DatumConverter.php
@@ -158,7 +158,6 @@ class DatumConverter
         }
 
         return false;
-
     }
 
     public function wrapImplicitVar(Query $q)

--- a/tests/Functional/DocumentTest.php
+++ b/tests/Functional/DocumentTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace r\Tests\Functional;
+
+use r\Tests\TestCase;
+
+class DocumentTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->conn = $this->getConnection();
+        $this->data = $this->useDataset('Heroes');
+        $this->data->populate();
+    }
+
+    public function tearDown()
+    {
+        $this->data->truncate();
+    }
+
+    public function testDocumentDefault()
+    {
+        $res = $this->db()->table('marvel')
+            ->get('Iron Man')
+            ->run($this->conn);
+
+        $this->assertInstanceOf('ArrayObject', $res);
+    }
+
+    public function testDocumentArrayObject()
+    {
+        $res = $this->db()->table('marvel')
+            ->get('Iron Man')
+            ->run($this->conn, array('documentFormat' => 'ArrayObject'));
+
+        $this->assertInstanceOf('ArrayObject', $res);
+    }
+
+    public function testDocumentNativeArray()
+    {
+        $res = $this->db()->table('marvel')
+            ->get('Iron Man')
+            ->run($this->conn, array('documentFormat' => 'array'));
+
+        $this->assertInternalType('array', $res);
+    }
+}


### PR DESCRIPTION
In a similar way to `dateFormat`/`binaryFormat`, this allows the user to specify the type of returned documents via the `documentFormat` option.

Passing 'array' will mean documents are returned as native arrays, otherwise documents will continue to be returned as `ArrayObject`'s.
