### PR TITLE
Rdb multiple args

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,20 @@
 {
-    "name": "danielmewes/php-rql",
+    "name": "geekimo/php-rql",
     "type": "library",
     "description": "A PHP client driver for the RethinkDB query language (ReQL)",
     "keywords": ["rethinkdb","driver","database","reql"],
-    "homepage": "http://danielmewes.github.io/php-rql/",
+    "homepage": "https://github.com/Geekimo/php-rql/",
     "license": "Apache-2.0",
     "authors": [
         {
             "name": "Daniel Mewes",
             "email": "danielmewes@onlinehome.de",
             "homepage": "http://dmewes.com",
+            "role": "Developer"
+        },
+        {
+            "name": "Morgan Abraham",
+            "email": "morgan@tramicms.net",
             "role": "Developer"
         }
     ],

--- a/rdb/Connection.php
+++ b/rdb/Connection.php
@@ -271,7 +271,6 @@ class Connection extends DatumConverter
         } else {
             return $this->createCursorFromResponse($response, $token, $response['n'], $toNativeOptions);
         }
-
     }
 
     public function continueQuery($token)

--- a/rdb/DatumConverter.php
+++ b/rdb/DatumConverter.php
@@ -158,7 +158,6 @@ class DatumConverter
         }
 
         return false;
-
     }
 
     public function wrapImplicitVar(Query $q)

--- a/rdb/Queries/Aggregations/Contains.php
+++ b/rdb/Queries/Aggregations/Contains.php
@@ -11,8 +11,7 @@ class Contains extends ValuedQuery
     {
         $this->setPositionalArg(0, $sequence);
 
-        foreach ($values as $k => $value)
-        {
+        foreach ($values as $k => $value) {
             $this->setPositionalArg($k+1, $this->nativeToDatumOrFunction($value));
         }
     }

--- a/rdb/Queries/Aggregations/Contains.php
+++ b/rdb/Queries/Aggregations/Contains.php
@@ -7,12 +7,13 @@ use r\ProtocolBuffer\TermTermType;
 
 class Contains extends ValuedQuery
 {
-    public function __construct(ValuedQuery $sequence, $value)
+    public function __construct(ValuedQuery $sequence, array $values)
     {
-        $value = $this->nativeToDatumOrFunction($value);
-
         $this->setPositionalArg(0, $sequence);
-        $this->setPositionalArg(1, $value);
+
+        foreach($values as $k => $value) {
+            $this->setPositionalArg($k+1, $this->nativeToDatumOrFunction($value));
+        }
     }
 
     protected function getTermType()

--- a/rdb/Queries/Aggregations/Contains.php
+++ b/rdb/Queries/Aggregations/Contains.php
@@ -11,7 +11,8 @@ class Contains extends ValuedQuery
     {
         $this->setPositionalArg(0, $sequence);
 
-        foreach($values as $k => $value) {
+        foreach ($values as $k => $value)
+        {
             $this->setPositionalArg($k+1, $this->nativeToDatumOrFunction($value));
         }
     }

--- a/rdb/Queries/Control/Branch.php
+++ b/rdb/Queries/Control/Branch.php
@@ -11,16 +11,13 @@ class Branch extends ValuedQuery
 {
     public function __construct(array $branches)
     {
-        if(count($branches) % 2 == 1)
-        {
+        if (count($branches) % 2 == 1) {
             // poping 'false' branch from other branches
             $falseBranch = $this->nativeToDatumOrFunction(array_pop($branches), false);
 
             // for each remaning branch, if the index is odd, this is a branch, so we convert, otherwise, we directly position the argument
-            foreach ($branches as $i => $branch)
-            {
-                if($i % 2 == 1)
-                {
+            foreach ($branches as $i => $branch) {
+                if($i % 2 == 1) {
                     // branch, so we convert
                     $branch = $this->nativeToDatumOrFunction($branch, false);
                 }
@@ -30,9 +27,7 @@ class Branch extends ValuedQuery
 
             // pushing the 'false' branch at the end of positional args
             $this->setPositionalArg(count($branches), $falseBranch);
-        }
-        else
-        {
+        } else {
             throw new RqlException(__METHOD__ . ' must have at least 3 parameters, or an odd parameter count.');
         }
     }

--- a/rdb/Queries/Control/Branch.php
+++ b/rdb/Queries/Control/Branch.php
@@ -9,10 +9,8 @@ use r\ProtocolBuffer\TermTermType;
 
 class Branch extends ValuedQuery
 {
-    public function __construct()
+    public function __construct($branches)
     {
-        $branches = func_get_args();
-
         if(count($branches) % 2 == 1)
         {
             // poping 'false' branch from other branches

--- a/rdb/Queries/Control/Branch.php
+++ b/rdb/Queries/Control/Branch.php
@@ -2,20 +2,41 @@
 
 namespace r\Queries\Control;
 
+use r\Exceptions\RqlException;
 use r\Query;
 use r\ValuedQuery\ValuedQuery;
 use r\ProtocolBuffer\TermTermType;
 
 class Branch extends ValuedQuery
 {
-    public function __construct(Query $test, $trueBranch, $falseBranch)
+    public function __construct()
     {
-        $trueBranch = $this->nativeToDatumOrFunction($trueBranch, false);
-        $falseBranch = $this->nativeToDatumOrFunction($falseBranch, false);
+        $branches = func_get_args();
 
-        $this->setPositionalArg(0, $test);
-        $this->setPositionalArg(1, $trueBranch);
-        $this->setPositionalArg(2, $falseBranch);
+        if(count($branches) % 2 == 1)
+        {
+            // poping 'false' branch from other branches
+            $falseBranch = $this->nativeToDatumOrFunction(array_pop($branches), false);
+
+            // for each remaning branch, if the index is odd, this is a branch, so we convert, otherwise, we directly position the argument
+            foreach ($branches as $i => $branch)
+            {
+                if($i % 2 == 1)
+                {
+                    // branch, so we convert
+                    $branch = $this->nativeToDatumOrFunction($branch, false);
+                }
+
+                $this->setPositionalArg($i, $branch);
+            }
+
+            // pushing the 'false' branch at the end of positional args
+            $this->setPositionalArg(count($branches), $falseBranch);
+        }
+        else
+        {
+            throw new RqlException(__METHOD__ . ' must have at least 3 parameters, or an odd parameter count.');
+        }
     }
 
     protected function getTermType()

--- a/rdb/Queries/Control/Branch.php
+++ b/rdb/Queries/Control/Branch.php
@@ -9,7 +9,7 @@ use r\ProtocolBuffer\TermTermType;
 
 class Branch extends ValuedQuery
 {
-    public function __construct($branches)
+    public function __construct(array $branches)
     {
         if(count($branches) % 2 == 1)
         {

--- a/rdb/Queries/Math/Add.php
+++ b/rdb/Queries/Math/Add.php
@@ -9,6 +9,6 @@ class Add extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_ADD, $value, $other);
+        parent::__construct(TermTermType::PB_ADD, [$value, $other]);
     }
 }

--- a/rdb/Queries/Math/Add.php
+++ b/rdb/Queries/Math/Add.php
@@ -9,6 +9,6 @@ class Add extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_ADD, [$value, $other]);
+        parent::__construct(TermTermType::PB_ADD, array($value, $other));
     }
 }

--- a/rdb/Queries/Math/BinaryOp.php
+++ b/rdb/Queries/Math/BinaryOp.php
@@ -6,12 +6,13 @@ use r\ValuedQuery\ValuedQuery;
 
 class BinaryOp extends ValuedQuery
 {
-    public function __construct($termType, $value, $other)
+    public function __construct($termType, array $exprs)
     {
         $this->termType = $termType;
 
-        $this->setPositionalArg(0, $this->nativeToDatum($value));
-        $this->setPositionalArg(1, $this->nativeToDatum($other));
+        foreach ($exprs as $k => $expr) {
+            $this->setPositionalArg($k, $this->nativeToDatum($expr));
+        }
     }
 
     protected function getTermType()

--- a/rdb/Queries/Math/Div.php
+++ b/rdb/Queries/Math/Div.php
@@ -9,6 +9,6 @@ class Div extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_DIV, $value, $other);
+        parent::__construct(TermTermType::PB_DIV, [$value, $other]);
     }
 }

--- a/rdb/Queries/Math/Div.php
+++ b/rdb/Queries/Math/Div.php
@@ -9,6 +9,6 @@ class Div extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_DIV, [$value, $other]);
+        parent::__construct(TermTermType::PB_DIV, array($value, $other));
     }
 }

--- a/rdb/Queries/Math/Eq.php
+++ b/rdb/Queries/Math/Eq.php
@@ -9,6 +9,6 @@ class Eq extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_EQ, $value, $other);
+        parent::__construct(TermTermType::PB_EQ, [$value, $other]);
     }
 }

--- a/rdb/Queries/Math/Eq.php
+++ b/rdb/Queries/Math/Eq.php
@@ -9,6 +9,6 @@ class Eq extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_EQ, [$value, $other]);
+        parent::__construct(TermTermType::PB_EQ, array($value, $other));
     }
 }

--- a/rdb/Queries/Math/Ge.php
+++ b/rdb/Queries/Math/Ge.php
@@ -8,6 +8,6 @@ class Ge extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_GE, $value, $other);
+        parent::__construct(TermTermType::PB_GE, [$value, $other]);
     }
 }

--- a/rdb/Queries/Math/Ge.php
+++ b/rdb/Queries/Math/Ge.php
@@ -8,6 +8,6 @@ class Ge extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_GE, [$value, $other]);
+        parent::__construct(TermTermType::PB_GE, array($value, $other));
     }
 }

--- a/rdb/Queries/Math/Gt.php
+++ b/rdb/Queries/Math/Gt.php
@@ -9,6 +9,6 @@ class Gt extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_GT, $value, $other);
+        parent::__construct(TermTermType::PB_GT, [$value, $other]);
     }
 }

--- a/rdb/Queries/Math/Gt.php
+++ b/rdb/Queries/Math/Gt.php
@@ -9,6 +9,6 @@ class Gt extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_GT, [$value, $other]);
+        parent::__construct(TermTermType::PB_GT, array($value, $other));
     }
 }

--- a/rdb/Queries/Math/Le.php
+++ b/rdb/Queries/Math/Le.php
@@ -8,6 +8,6 @@ class Le extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_LE, $value, $other);
+        parent::__construct(TermTermType::PB_LE, [$value, $other]);
     }
 }

--- a/rdb/Queries/Math/Le.php
+++ b/rdb/Queries/Math/Le.php
@@ -8,6 +8,6 @@ class Le extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_LE, [$value, $other]);
+        parent::__construct(TermTermType::PB_LE, array($value, $other));
     }
 }

--- a/rdb/Queries/Math/Lt.php
+++ b/rdb/Queries/Math/Lt.php
@@ -8,6 +8,6 @@ class Lt extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_LT, $value, $other);
+        parent::__construct(TermTermType::PB_LT, [$value, $other]);
     }
 }

--- a/rdb/Queries/Math/Lt.php
+++ b/rdb/Queries/Math/Lt.php
@@ -8,6 +8,6 @@ class Lt extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_LT, [$value, $other]);
+        parent::__construct(TermTermType::PB_LT, array($value, $other));
     }
 }

--- a/rdb/Queries/Math/Mod.php
+++ b/rdb/Queries/Math/Mod.php
@@ -8,6 +8,6 @@ class Mod extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_MOD, $value, $other);
+        parent::__construct(TermTermType::PB_MOD, [$value, $other]);
     }
 }

--- a/rdb/Queries/Math/Mod.php
+++ b/rdb/Queries/Math/Mod.php
@@ -8,6 +8,6 @@ class Mod extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_MOD, [$value, $other]);
+        parent::__construct(TermTermType::PB_MOD, array($value, $other));
     }
 }

--- a/rdb/Queries/Math/Mul.php
+++ b/rdb/Queries/Math/Mul.php
@@ -8,6 +8,6 @@ class Mul extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_MUL, [$value, $other]);
+        parent::__construct(TermTermType::PB_MUL, array($value, $other));
     }
 }

--- a/rdb/Queries/Math/Mul.php
+++ b/rdb/Queries/Math/Mul.php
@@ -8,6 +8,6 @@ class Mul extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_MUL, $value, $other);
+        parent::__construct(TermTermType::PB_MUL, [$value, $other]);
     }
 }

--- a/rdb/Queries/Math/Ne.php
+++ b/rdb/Queries/Math/Ne.php
@@ -9,6 +9,6 @@ class Ne extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_NE, $value, $other);
+        parent::__construct(TermTermType::PB_NE, [$value, $other]);
     }
 }

--- a/rdb/Queries/Math/Ne.php
+++ b/rdb/Queries/Math/Ne.php
@@ -9,6 +9,6 @@ class Ne extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_NE, [$value, $other]);
+        parent::__construct(TermTermType::PB_NE, array($value, $other));
     }
 }

--- a/rdb/Queries/Math/RAnd.php
+++ b/rdb/Queries/Math/RAnd.php
@@ -6,8 +6,8 @@ use r\ProtocolBuffer\TermTermType;
 
 class RAnd extends BinaryOp
 {
-    public function __construct($value, $other)
+    public function __construct(array $exprs)
     {
-        parent::__construct(TermTermType::PB_AND, $value, $other);
+        parent::__construct(TermTermType::PB_AND, $exprs);
     }
 }

--- a/rdb/Queries/Math/ROr.php
+++ b/rdb/Queries/Math/ROr.php
@@ -6,8 +6,8 @@ use r\ProtocolBuffer\TermTermType;
 
 class ROr extends BinaryOp
 {
-    public function __construct($value, $other)
+    public function __construct(array $exprs)
     {
-        parent::__construct(TermTermType::PB_OR, $value, $other);
+        parent::__construct(TermTermType::PB_OR, $exprs);
     }
 }

--- a/rdb/Queries/Math/Sub.php
+++ b/rdb/Queries/Math/Sub.php
@@ -8,6 +8,6 @@ class Sub extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_SUB, [$value, $other]);
+        parent::__construct(TermTermType::PB_SUB, array($value, $other));
     }
 }

--- a/rdb/Queries/Math/Sub.php
+++ b/rdb/Queries/Math/Sub.php
@@ -8,6 +8,6 @@ class Sub extends BinaryOp
 {
     public function __construct($value, $other)
     {
-        parent::__construct(TermTermType::PB_SUB, $value, $other);
+        parent::__construct(TermTermType::PB_SUB, [$value, $other]);
     }
 }

--- a/rdb/ValuedQuery/ValuedQuery.php
+++ b/rdb/ValuedQuery/ValuedQuery.php
@@ -339,7 +339,7 @@ abstract class ValuedQuery extends Query
     }
     public function rAnd()
     {
-        $exprs = funct_get_args();
+        $exprs = func_get_args();
         
         array_unshift($exprs, $this);
 
@@ -347,7 +347,7 @@ abstract class ValuedQuery extends Query
     }
     public function rOr()
     {
-        $exprs = funct_get_args();
+        $exprs = func_get_args();
         
         array_unshift($exprs, $this);
 

--- a/rdb/ValuedQuery/ValuedQuery.php
+++ b/rdb/ValuedQuery/ValuedQuery.php
@@ -240,9 +240,9 @@ abstract class ValuedQuery extends Query
     }
     // Note: The API docs suggest that as of 1.6, contains can accept multiple values.
     //  We do not support that for the time being.
-    public function contains($value)
+    public function contains(...$values)
     {
-        return new Contains($this, $value);
+        return new Contains($this, $values);
     }
     public function pluck($attributes)
     {
@@ -337,13 +337,17 @@ abstract class ValuedQuery extends Query
     {
         return new Mod($this, $other);
     }
-    public function rAnd($other)
+    public function rAnd(...$exprs)
     {
-        return new RAnd($this, $other);
+        array_unshift($exprs, $this);
+
+        return new RAnd($exprs);
     }
-    public function rOr($other)
+    public function rOr(...$exprs)
     {
-        return new ROr($this, $other);
+        array_unshift($exprs, $this);
+
+        return new ROr($exprs);
     }
     public function eq($other)
     {

--- a/rdb/ValuedQuery/ValuedQuery.php
+++ b/rdb/ValuedQuery/ValuedQuery.php
@@ -337,14 +337,18 @@ abstract class ValuedQuery extends Query
     {
         return new Mod($this, $other);
     }
-    public function rAnd(...$exprs)
+    public function rAnd()
     {
+        $exprs = funct_get_args();
+        
         array_unshift($exprs, $this);
 
         return new RAnd($exprs);
     }
-    public function rOr(...$exprs)
+    public function rOr()
     {
+        $exprs = funct_get_args();
+        
         array_unshift($exprs, $this);
 
         return new ROr($exprs);

--- a/rdb/ValuedQuery/ValuedQuery.php
+++ b/rdb/ValuedQuery/ValuedQuery.php
@@ -240,9 +240,9 @@ abstract class ValuedQuery extends Query
     }
     // Note: The API docs suggest that as of 1.6, contains can accept multiple values.
     //  We do not support that for the time being.
-    public function contains(...$values)
+    public function contains()
     {
-        return new Contains($this, $values);
+        return new Contains($this, func_get_args());
     }
     public function pluck($attributes)
     {

--- a/rdb/global.php
+++ b/rdb/global.php
@@ -238,13 +238,13 @@ function mod($expr1, $expr2)
     return new Mod($expr1, $expr2);
 }
 
-function rAnd(...$exprs)
+function rAnd()
 {
-    return new RAnd($exprs);
+    return new RAnd(func_get_args());
 }
-function rOr(...$exprs)
+function rOr()
 {
-    return new ROr($exprs);
+    return new ROr(func_get_args());
 }
 
 function eq($expr1, $expr2)

--- a/rdb/global.php
+++ b/rdb/global.php
@@ -135,9 +135,9 @@ function args($args)
     return new Args($args);
 }
 
-function branch(Query $test, $trueBranch, $falseBranch)
+function branch()
 {
-    return new Branch($test, $trueBranch, $falseBranch);
+    return new Branch(func_get_args());
 }
 
 function row($attribute = null)

--- a/rdb/global.php
+++ b/rdb/global.php
@@ -238,13 +238,13 @@ function mod($expr1, $expr2)
     return new Mod($expr1, $expr2);
 }
 
-function rAnd($expr1, $expr2)
+function rAnd(...$exprs)
 {
-    return new RAnd($expr1, $expr2);
+    return new RAnd($exprs);
 }
-function rOr($expr1, $expr2)
+function rOr(...$exprs)
 {
-    return new ROr($expr1, $expr2);
+    return new ROr($exprs);
 }
 
 function eq($expr1, $expr2)


### PR DESCRIPTION
Adding php-rql multiple (>2) arguments support for the following API functions:
- rOr
- rAnd
- contains

Plus a few enhancements for PSR-2 support.
