### PR TITLE
Add test to prevent autoloader bug

### DIFF
--- a/rdb/Connection.php
+++ b/rdb/Connection.php
@@ -271,7 +271,6 @@ class Connection extends DatumConverter
         } else {
             return $this->createCursorFromResponse($response, $token, $response['n'], $toNativeOptions);
         }
-
     }
 
     public function continueQuery($token)

--- a/rdb/DatumConverter.php
+++ b/rdb/DatumConverter.php
@@ -158,7 +158,6 @@ class DatumConverter
         }
 
         return false;
-
     }
 
     public function wrapImplicitVar(Query $q)

--- a/rdb/DatumConverter.php
+++ b/rdb/DatumConverter.php
@@ -34,7 +34,7 @@ class DatumConverter
                 if (!is_numeric($key) && !is_string($key)) {
                     throw new RqlDriverError("Key must be a string.");
                 }
-                if (is_subclass_of($val, "\\r\\Query") && !is_subclass_of($val, '\r\Datum\Datum')) {
+                if (!is_string($val) && is_subclass_of($val, "\\r\\Query") && !is_subclass_of($val, '\r\Datum\Datum')) {
                     $subDatum = $val;
                     $mustUseMakeTerm = true;
                 } else {


### PR DESCRIPTION
Not testing if $val is a string before testing if it is a subclass can cause autoloader class to abnormally load a class which match string value in include directory.